### PR TITLE
Adding CONP_status to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -55,6 +55,14 @@
 			]
 		},
 		{
+			"category": "CONP_status",
+			"values": [
+				{
+					"value": "external"
+				}
+			]
+		},
+		{
 			"category": "files",
 			"values": [
 				{


### PR DESCRIPTION
This PR adds one additional field to DATS.json, extra_properties->CONP_status, indicating whether a dataset was generated in Canada.